### PR TITLE
Release 11.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [11.0.1] - 2025-06-04
+
+### Removed
+- Unused return statement from `Debounceable::handle`.
+- `@return` annotation from `debouncedHandle`.
 
 ## [11.0.0] - 2024-06-23
 

--- a/src/Debounce/Debounceable.php
+++ b/src/Debounce/Debounceable.php
@@ -61,6 +61,6 @@ trait Debounceable
 
         Cache::forget('debounceable_' . $this->getIdForDebounce());
 
-        return $this->debouncedHandle();
+        $this->debouncedHandle();
     }
 }

--- a/src/Debounce/ShouldDebounce.php
+++ b/src/Debounce/ShouldDebounce.php
@@ -17,7 +17,7 @@ interface ShouldDebounce extends ShouldQueue
     public function getIdForDebounce(): string;
 
     /**
-     * @return bool|void
+     * Execute the debounced job.
      */
     public function debouncedHandle();
 }


### PR DESCRIPTION
## Summary
- categorize removal of return statement and docblock in changelog
- keep code adjustments from prior commit

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840dd9dd8d88320907fec4f569ce933