### PR TITLE
Fix README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ composer require reyesoft/reactive-laravel-jobs
 * A same job dispatched various times can be grouped based on some value, like user_id.
 * Delay time can be changed (takes last delay value).
 
-## Fantastic Laravel jobs types
+## Fantastic Laravel job types
 
 ### Debounce Laravel Job
 


### PR DESCRIPTION
## Summary
- correct a typo in the README heading

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840e4923af08320845cad76957a8126